### PR TITLE
46 feat estimate token count of image input

### DIFF
--- a/example-ollama-ii.py
+++ b/example-ollama-ii.py
@@ -1,0 +1,56 @@
+"""
+This file aims to compare the prompt_eval_count of different vision models.
+
+Apparently `llama3.2-vision:latest` consumption on image was not reflected on prompt_eval_count
+and none of the tested models uses OpenAI's calculation.
+"""
+
+import logging
+from llm_agent_toolkit.core.local import OllamaCore
+from llm_agent_toolkit import ChatCompletionConfig
+from llm_agent_toolkit.core.local import Image_to_Text
+
+logging.basicConfig(
+    filename="./snippet/output/example-ollama-ii.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+CONNECTION_STRING = "http://localhost:11434"
+STANDARD_CHAT_COMPLETION_CONFIG = {
+    "return_n": 1,
+    "max_iteration": 5,
+    "max_tokens": 4096,
+    "max_output_tokens": 2048,
+    "temperature": 0.7,
+}  # max_iteration takes no effect when no tool is used
+
+
+def execute(model_name: str, filepath: str | None) -> None:
+    SYSTEM_PROMPT = "You are Whales, faithful AI assistant."
+    QUERY = "What's in the image?"
+
+    config = ChatCompletionConfig(name=model_name, **STANDARD_CHAT_COMPLETION_CONFIG)
+    llm = Image_to_Text(
+        connection_string=CONNECTION_STRING,
+        system_prompt=SYSTEM_PROMPT,
+        config=config,
+    )
+    results = llm.run(query=QUERY, context=None, filepath=filepath)
+    logger.info("Query: %s", QUERY)
+    for result in results:
+        logger.info(">>>> %s\n", result)
+
+
+if __name__ == "__main__":
+    OllamaCore.load_csv("./files/ollama.csv")
+
+    models = ["llama3.2-vision:latest", "llava:7b", "llava-llama3:latest"]
+    FILEPATH = "./dev/jonah-pixel-art.jpeg"
+
+    for model in models:
+        logger.info("Model: %s", model)
+        execute(model, None)
+        execute(model, FILEPATH)

--- a/example-ollama.py
+++ b/example-ollama.py
@@ -5,7 +5,7 @@ Please do not take this as tests.
 
 import asyncio
 import logging
-
+from llm_agent_toolkit.core.local import OllamaCore
 
 logging.basicConfig(
     filename="./snippet/output/example-ollama.log",
@@ -323,4 +323,5 @@ def try_ollama_examples():
 
 
 if __name__ == "__main__":
+    OllamaCore.load_csv("./files/ollama.csv")
     try_ollama_examples()

--- a/files/ollama.csv
+++ b/files/ollama.csv
@@ -11,3 +11,4 @@ llama3.2:3b,131072,,TRUE,TRUE,TRUE,,,TRUE,,,
 llama3.2:1b,131072,2048,TRUE,TRUE,TRUE,,,TRUE,,,https://www.prompthub.us/resources/llm-model-card-directory
 llama3.2-vision:11b,131072,,TRUE,,TRUE,TRUE,,TRUE,,,
 mistral-nemo:latest,128000,4096,TRUE,TRUE,TRUE,,,TRUE,,,Context-length=1024000
+llama3.2-vision:latest,131072,,TRUE,,TRUE,TRUE,,TRUE,,,

--- a/llm_agent_toolkit/core/local/i2t.py
+++ b/llm_agent_toolkit/core/local/i2t.py
@@ -97,7 +97,9 @@ class I2T_OLM_Core(Core, OllamaCore, ImageInterpreter):  # , ToolSupport
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs, None, images=[filepath] if filepath else None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -122,6 +124,11 @@ class I2T_OLM_Core(Core, OllamaCore, ImageInterpreter):  # , ToolSupport
                     role=CreatorRole.ASSISTANT.value,
                     content=llm_generated_content,
                 )
+            )
+            logger.info(
+                ">>>> Actual Consumption: %d + %d",
+                response["prompt_eval_count"],
+                response["eval_count"],
             )
 
             return msgs[NUMBER_OF_PRIMERS:]  # Return only the generated messages
@@ -172,7 +179,9 @@ class I2T_OLM_Core(Core, OllamaCore, ImageInterpreter):  # , ToolSupport
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs, None, images=[filepath] if filepath else None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -197,6 +206,12 @@ class I2T_OLM_Core(Core, OllamaCore, ImageInterpreter):  # , ToolSupport
                     role=CreatorRole.ASSISTANT.value,
                     content=llm_generated_content,
                 )
+            )
+
+            logger.info(
+                ">>>> Actual Consumption: %d + %d",
+                response["prompt_eval_count"],
+                response["eval_count"],
             )
 
             return msgs[NUMBER_OF_PRIMERS:]  # Return only the generated messages

--- a/llm_agent_toolkit/core/local/i2tso.py
+++ b/llm_agent_toolkit/core/local/i2tso.py
@@ -128,7 +128,9 @@ class I2TSO_OLM_Core(Core, OllamaCore, ImageInterpreter):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs, None, images=[filepath] if filepath else None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -262,7 +264,9 @@ class I2TSO_OLM_Core(Core, OllamaCore, ImageInterpreter):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs, None, images=[filepath] if filepath else None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -313,7 +317,6 @@ class I2TSO_OLM_Core(Core, OllamaCore, ImageInterpreter):
                     },
                 )
 
-            logger.info("%s => %s", response_mode, response)
             llm_generated_content: str = response["message"]["content"]
 
             # Update the accumulated token count

--- a/llm_agent_toolkit/core/local/t2t.py
+++ b/llm_agent_toolkit/core/local/t2t.py
@@ -94,7 +94,7 @@ class T2T_OLM_Core(Core, OllamaCore, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(msgs, tools_metadata, None)
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -139,7 +139,9 @@ class T2T_OLM_Core(Core, OllamaCore, ToolSupport):
 
                 # Below are the early termination conditions
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs, tools_metadata, None
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,
@@ -216,7 +218,7 @@ class T2T_OLM_Core(Core, OllamaCore, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(msgs, tools_metadata, None)
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -261,7 +263,9 @@ class T2T_OLM_Core(Core, OllamaCore, ToolSupport):
 
                 # Below are the early termination conditions
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs, tools_metadata, None
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,

--- a/llm_agent_toolkit/core/local/t2tso.py
+++ b/llm_agent_toolkit/core/local/t2tso.py
@@ -110,7 +110,7 @@ class T2TSO_OLM_Core(Core, OllamaCore):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(msgs, None, None)
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -228,7 +228,7 @@ class T2TSO_OLM_Core(Core, OllamaCore):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(msgs, None, None)
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,

--- a/llm_agent_toolkit/core/open_ai/i2t.py
+++ b/llm_agent_toolkit/core/open_ai/i2t.py
@@ -93,14 +93,28 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
 
         filepath: str | None = kwargs.get("filepath", None)
         if filepath:
-            img_url = self.get_image_url(filepath)
+            # detail hardcode as "high"
+            resized, newpath = self.resize(filepath, "high")
+            if resized and newpath:
+                img_url = self.get_image_url(newpath)
+                os.remove(newpath)
+            else:
+                img_url = self.get_image_url(filepath)
+
             msgs.append(
                 {
                     "role": CreatorRole.USER.value,
-                    "content": [{"type": "image_url", "image_url": {"url": img_url}}],  # type: ignore
+                    "content": [
+                        {"type": "text", "text": query},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": img_url, "detail": "high"},
+                        },
+                    ],  # type: ignore
                 }
             )
-        msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
+        else:
+            msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
 
         tools_metadata: list[ToolMetadata] | None = None
         if self.tools:
@@ -115,7 +129,12 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(
+            msgs,
+            tools_metadata,
+            images=[filepath] if filepath else None,
+            image_detail="high" if filepath else None,
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -156,7 +175,12 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
                     msgs.extend(output)
 
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs,
+                    tools_metadata,
+                    images=[filepath] if filepath else None,
+                    image_detail="high" if filepath else None,
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,
@@ -220,14 +244,28 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
 
         filepath: str | None = kwargs.get("filepath", None)
         if filepath:
-            img_url = self.get_image_url(filepath)
+            # detail hardcode as "high"
+            resized, newpath = self.resize(filepath, "high")
+            if resized and newpath:
+                img_url = self.get_image_url(newpath)
+                os.remove(newpath)
+            else:
+                img_url = self.get_image_url(filepath)
+
             msgs.append(
                 {
                     "role": CreatorRole.USER.value,
-                    "content": [{"type": "image_url", "image_url": {"url": img_url}}],  # type: ignore
+                    "content": [
+                        {"type": "text", "text": query},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": img_url, "detail": "high"},
+                        },
+                    ],  # type: ignore
                 }
             )
-        msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
+        else:
+            msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
 
         tools_metadata: list[ToolMetadata] | None = None
         if self.tools:
@@ -242,7 +280,12 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(
+            msgs,
+            tools_metadata,
+            images=[filepath] if filepath else None,
+            image_detail="high" if filepath else None,
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -283,7 +326,12 @@ class I2T_OAI_Core(Core, OpenAICore, ImageInterpreter, ToolSupport):
                     msgs.extend(output)
 
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs,
+                    tools_metadata,
+                    images=[filepath] if filepath else None,
+                    image_detail="high" if filepath else None,
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,

--- a/llm_agent_toolkit/core/open_ai/so.py
+++ b/llm_agent_toolkit/core/open_ai/so.py
@@ -120,24 +120,43 @@ class OAI_StructuredOutput_Core(Core, OpenAICore, ImageInterpreter):
 
         if context:
             msgs.extend(context)
-        msgs.append({"role": CreatorRole.USER.value, "content": query})
 
         filepath: str | None = kwargs.get("filepath", None)
         if filepath:
-            img_url = self.get_image_url(filepath)
+            # detail hardcode as "high"
+            resized, newpath = self.resize(filepath, "high")
+            if resized and newpath:
+                img_url = self.get_image_url(newpath)
+                os.remove(newpath)
+            else:
+                img_url = self.get_image_url(filepath)
+
             msgs.append(
                 {
                     "role": CreatorRole.USER.value,
-                    "content": [{"type": "image_url", "image_url": {"url": img_url}}],  # type: ignore
+                    "content": [
+                        {"type": "text", "text": query},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": img_url, "detail": "high"},
+                        },
+                    ],  # type: ignore
                 }
             )
+        else:
+            msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
 
         # Determine the maximum number of tokens allowed for the response
         MAX_TOKENS = min(self.config.max_tokens, self.context_length)
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs,
+            None,
+            images=[filepath] if filepath else None,
+            image_detail="high" if filepath else None,
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -247,24 +266,43 @@ class OAI_StructuredOutput_Core(Core, OpenAICore, ImageInterpreter):
 
         if context:
             msgs.extend(context)
-        msgs.append({"role": CreatorRole.USER.value, "content": query})
 
         filepath: str | None = kwargs.get("filepath", None)
         if filepath:
-            img_url = self.get_image_url(filepath)
+            # detail hardcode as "high"
+            resized, newpath = self.resize(filepath, "high")
+            if resized and newpath:
+                img_url = self.get_image_url(newpath)
+                os.remove(newpath)
+            else:
+                img_url = self.get_image_url(filepath)
+
             msgs.append(
                 {
                     "role": CreatorRole.USER.value,
-                    "content": [{"type": "image_url", "image_url": {"url": img_url}}],  # type: ignore
+                    "content": [
+                        {"type": "text", "text": query},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": img_url, "detail": "high"},
+                        },
+                    ],  # type: ignore
                 }
             )
+        else:
+            msgs.append(MessageBlock(role=CreatorRole.USER.value, content=query))
 
         # Determine the maximum number of tokens allowed for the response
         MAX_TOKENS = min(self.config.max_tokens, self.context_length)
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, None)
+        prompt_token_count = self.calculate_token_count(
+            msgs,
+            None,
+            images=[filepath] if filepath else None,
+            image_detail="high" if filepath else None,
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,

--- a/llm_agent_toolkit/core/open_ai/t2t.py
+++ b/llm_agent_toolkit/core/open_ai/t2t.py
@@ -92,7 +92,9 @@ class T2T_OAI_Core(Core, OpenAICore, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(
+            msgs, tools_metadata, None, None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -133,7 +135,9 @@ class T2T_OAI_Core(Core, OpenAICore, ToolSupport):
                     msgs.extend(output)
 
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs, tools_metadata, None, None
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,
@@ -208,7 +212,9 @@ class T2T_OAI_Core(Core, OpenAICore, ToolSupport):
         MAX_OUTPUT_TOKENS = min(
             MAX_TOKENS, self.max_output_tokens, self.config.max_output_tokens
         )
-        prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+        prompt_token_count = self.calculate_token_count(
+            msgs, tools_metadata, None, None
+        )
         max_output_tokens = min(
             MAX_OUTPUT_TOKENS,
             self.context_length - prompt_token_count,
@@ -249,7 +255,9 @@ class T2T_OAI_Core(Core, OpenAICore, ToolSupport):
                     msgs.extend(output)
 
                 solved = tool_calls is None
-                prompt_token_count = self.calculate_token_count(msgs, tools_metadata)
+                prompt_token_count = self.calculate_token_count(
+                    msgs, tools_metadata, None, None
+                )
                 max_output_tokens = min(
                     MAX_OUTPUT_TOKENS,
                     self.context_length - prompt_token_count,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ DESCRIPTION = "LLM Agent Toolkit provides minimal, modular interfaces for core c
 # python3 setup.py sdist bdist_wheel
 # twine upload --skip-existing dist/* --verbose
 
-VERSION = "0.0.22"
+VERSION = "0.0.23"
 
 with open("./README.md", "r", encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
Apparently `llama3.2-vision:latest` consumption on image was not reflected on `prompt_eval_count` and none of the tested models uses OpenAI's calculation and each has their own calculation.

Tested Models:

- llama3.2-vision:latest
- llava:7b
- llava-llama3:latest