### PR TITLE
111 bug generate chunk is greater than configchunk size

### DIFF
--- a/llm_agent_toolkit/_chunkers.py
+++ b/llm_agent_toolkit/_chunkers.py
@@ -145,13 +145,13 @@ class RandomInitializer:
                     index = random.randint(0, self.k - 1)
                     init_list[index] += 1
                 break    # All remaining capacity has been distributed
-            # Randomly decide how much to add to each chunk in this iteration
-            new_growth = [random.randint(1, even_size) for _ in range(self.k)]
+
             # Add the new growth to each chunk's size
             for index in range(self.k):
-                init_list[index] += new_growth[index]
+                # Randomly decide how much to add to each chunk in this iteration
+                init_list[index] += random.randint(1, even_size)
             # Decrease the remaining capacity by the total allocated in this iteration
-            remainer -= sum(new_growth)
+            remainer = self.total_capacity - sum(init_list)
 
         offset = 0
         output_list: list[tuple[int, int]] = []    # type: ignore
@@ -175,5 +175,6 @@ class Splitter(Protocol):
 
 @runtime_checkable
 class AsyncSplitter(Protocol):
+
     async def split(self, long_text: str) -> list[str]:
         ...

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -659,7 +659,7 @@ class HybridChunker:
 
                     splitter = FixedCharacterChunker(
                         FixedCharacterChunkerConfig(
-                            chunk_length=int(self.config.chunk_size * 0.5),
+                            chunk_length=ceil(self.config.chunk_size * 0.25),
                             stride_rate=1.0
                         )
                     )
@@ -1295,7 +1295,7 @@ class AsyncHybridChunker:
 
                     splitter = FixedCharacterChunker(
                         FixedCharacterChunkerConfig(
-                            chunk_length=int(self.config.chunk_size * 0.5),
+                            chunk_length=int(self.config.chunk_size * 0.25),
                             stride_rate=1.0
                         )
                     )

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -663,13 +663,11 @@ class HybridChunker:
                     L = len(sentences)
 
                 # When distributed evenly, every chunks are about chunk_size.
-                # 20 sentences per group
+                g_by_token_count = ceil(est_tc / shifted_chunk_size)
+                # 15 sentences per group
+                g_by_sentence_len = ceil(L / 15)
                 # At least 2 groups
-                G: int = max(
-                    2,
-                    int(est_tc // self.config.chunk_size),
-                    L // 20,
-                )
+                G: int = max(2, g_by_token_count, g_by_sentence_len)
                 grouping = self.find_best_grouping(sentences, G)
                 for g_start, g_end in grouping:
                     g_chunk = reconstruct_chunk_v2(
@@ -1297,13 +1295,11 @@ class AsyncHybridChunker:
                     L = len(sentences)
 
                 # When distributed evenly, every chunks are about chunk_size.
-                # 20 sentences per group
+                g_by_token_count = ceil(est_tc / shifted_chunk_size)
+                # 15 sentences per group
+                g_by_sentence_len = ceil(L / 15)
                 # At least 2 groups
-                G: int = max(
-                    2,
-                    int(est_tc // self.config.chunk_size),
-                    L // 20,
-                )
+                G: int = max(2, g_by_token_count, g_by_sentence_len)
                 grouping = await self.find_best_grouping(sentences, G)
                 for g_start, g_end in grouping:
                     g_chunk = reconstruct_chunk_v2(

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -791,12 +791,16 @@ class HybridChunker:
 
             iteration += 1
             logger.warning("======= [%d] =======", iteration)
-            if random.random() < self.config.randomness:
+            if score != best_score and random.random() < self.config.randomness:
                 logger.warning("Initializing new random grouping")
                 grouping = initializer.init()
             else:
-                logger.warning("Step forward")
-                grouping = self.step_forward(grouping, L)
+                if not within_chunk_size or coverage < self.config.min_coverage:
+                    logger.warning("Revert to best grouping")
+                    grouping = best_grouping[:]
+                else:
+                    logger.warning("Step forward")
+                    grouping = self.step_forward(grouping, L)
             logger.warning("Grouping: %s", grouping)
 
         score: float = self.eval(lines, grouping, L, True)
@@ -1421,12 +1425,16 @@ class AsyncHybridChunker:
 
             iteration += 1
             logger.warning("======= [%d] =======", iteration)
-            if random.random() < self.config.randomness:
+            if score != best_score and random.random() < self.config.randomness:
                 logger.warning("Initializing new random grouping")
                 grouping = initializer.init()
             else:
-                logger.warning("Step forward")
-                grouping = self.step_forward(grouping, L)
+                if not within_chunk_size or coverage < self.config.min_coverage:
+                    logger.warning("Revert to best grouping")
+                    grouping = best_grouping[:]
+                else:
+                    logger.warning("Step forward")
+                    grouping = self.step_forward(grouping, L)
             logger.warning("Grouping: %s", grouping)
 
         score: float = await self.eval(lines, grouping, L, True)

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -1429,7 +1429,7 @@ class AsyncHybridChunker:
                 grouping = self.step_forward(grouping, L)
             logger.warning("Grouping: %s", grouping)
 
-        score: float = self.eval(lines, grouping, L, True)
+        score: float = await self.eval(lines, grouping, L, True)
         coverage: float = ChunkerMetrics.calculate_coverage(L, grouping)
         within_chunk_size: bool = all_within_chunk_size(
             lines, grouping, self.config.chunk_size

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -769,6 +769,12 @@ class HybridChunker:
         logger.warning("Lines: %d, Groups: %d", L, G)
         logger.warning("======= [%d] =======", iteration)
         logger.warning("Grouping: %s", grouping)
+        within_chunk_size: bool = all_within_chunk_size(
+            lines, grouping, self.config.chunk_size
+        )
+
+        assert within_chunk_size, "All chunks should be within chunk size."
+
         while iteration < self.config.max_iteration:
             score: float = self.eval(lines, grouping, L, True)
             if score - best_score < self.config.delta:
@@ -1405,6 +1411,12 @@ class AsyncHybridChunker:
         logger.warning("Lines: %d, Groups: %d", L, G)
         logger.warning("======= [%d] =======", iteration)
         logger.warning("Grouping: %s", grouping)
+        within_chunk_size: bool = all_within_chunk_size(
+            lines, grouping, self.config.chunk_size
+        )
+
+        assert within_chunk_size, "All chunks should be within chunk size."
+
         while iteration < self.config.max_iteration:
             score: float = await self.eval(lines, grouping, L, True)
             if score - best_score < self.config.delta:

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -636,11 +636,15 @@ class HybridChunker:
         section_chunker = SectionChunker()
         sentence_chunker = SentenceChunker()
 
+        # Since the token estimation is not exact, we need to
+        # shrink the chunk size to avoid overflow.
+        shifted_chunk_size: int = ceil(self.config.chunk_size * 0.8)
+
         output: list[str] = []
         temp: str = ""
         for section in section_chunker.split(text):
             est_tc = estimate_token_count(section)
-            if est_tc > self.config.chunk_size:
+            if est_tc > shifted_chunk_size:
                 logger.warning("Content:\n%s", section)
                 sentences = sentence_chunker.split(section)
                 L = len(sentences)
@@ -1268,11 +1272,15 @@ class AsyncHybridChunker:
         section_chunker = SectionChunker()
         sentence_chunker = SentenceChunker()
 
+        # Since the token estimation is not exact, we need to
+        # shrink the chunk size to avoid overflow.
+        shifted_chunk_size: int = ceil(self.config.chunk_size * 0.8)
+
         output: list[str] = []
         temp: str = ""
         for section in section_chunker.split(text):
             est_tc = estimate_token_count(section)
-            if est_tc > self.config.chunk_size:
+            if est_tc > shifted_chunk_size:
                 logger.warning("Content:\n%s", section)
                 sentences = sentence_chunker.split(section)
                 L = len(sentences)

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -801,7 +801,13 @@ class HybridChunker:
 
         score: float = self.eval(lines, grouping, L, True)
         coverage: float = ChunkerMetrics.calculate_coverage(L, grouping)
-        if score > best_score and coverage >= self.config.min_coverage:
+        within_chunk_size: bool = all_within_chunk_size(
+            lines, grouping, self.config.chunk_size
+        )
+        if (
+            score > best_score and coverage >= self.config.min_coverage
+            and within_chunk_size
+        ):
             best_score = score
             best_grouping = grouping[:]
             logger.warning("Improved! Score: %.4f.", score)

--- a/llm_agent_toolkit/chunkers/hybrid.py
+++ b/llm_agent_toolkit/chunkers/hybrid.py
@@ -812,26 +812,6 @@ class HybridChunker:
         logger.warning("[END] find_best_grouping")
         return best_grouping
 
-    @staticmethod
-    def reconstruct_chunk_v2(partial_chunk: list[str], level: str) -> str:
-        """
-        Reconstructs a text chunk from a list of text units.
-
-        The reconstruction method depends on the specified level (e.g., "section"
-        or "sentence").
-
-        Args:
-            partial_chunk (List[str]): A list of text units.
-            level (str): The level of text unit ("section" or "sentence").
-
-        Returns:
-            output (str): 
-            The reconstructed text chunk.
-        """
-        if level == "section":
-            return "\n\n".join([chunk.strip() for chunk in partial_chunk])
-        return " ".join([chunk.strip() for chunk in partial_chunk])
-
 
 class AsyncHybridChunker:
     """


### PR DESCRIPTION
# Estimation of G
```python
sentences = splitter.split(section)
L = len(sentences)
# When distributed evenly, every chunks are about chunk_size.
g_by_token_count = ceil(est_tc / shifted_chunk_size)
# 15 sentences per group
g_by_sentence_len = ceil(L / 15)
# At least 2 groups
G: int = max(2, g_by_token_count, g_by_sentence_len)
```

# Capture Rules
```python
# Assume the initial state actually fulfill constraints
assert within_chunk_size, "All chunks should be within chunk size."

if (
    score > best_score
    and coverage >= self.config.min_coverage
    and within_chunk_size
):
    # Capture state

# Step-forward | Re-initialize | Revert
if score != best_score and random.random() < self.config.randomness:
    # Re-initialize
    grouping = initializer.init()
else:
    if not within_chunk_size or coverage < self.config.min_coverage:
        # Revert
        grouping = best_grouping[:]
    else:
        # Step-forward
        grouping = self.step_forward(grouping, L)
```